### PR TITLE
Fixes #112 DOM document should be bound to widget

### DIFF
--- a/lib/Widget.js
+++ b/lib/Widget.js
@@ -283,9 +283,9 @@ Widget.prototype = widgetProto = {
     },
     getEl: function (widgetElId, index) {
         if (widgetElId != null) {
-            return document.getElementById(this.getElId(widgetElId, index));
+            return this.document.getElementById(this.getElId(widgetElId, index));
         } else {
-            return this.el || document.getElementById(this.getElId());
+            return this.el || this.document.getElementById(this.getElId());
         }
     },
     getEls: function(id) {
@@ -303,7 +303,7 @@ Widget.prototype = widgetProto = {
     },
     getWidget: function(id, index) {
         var targetWidgetId = this.getElId(id, index);
-        return markoWidgets.getWidgetForEl(targetWidgetId);
+        return markoWidgets.getWidgetForEl(targetWidgetId, this.document);
     },
     getWidgets: function(id) {
         var widgets = [];
@@ -518,7 +518,7 @@ Widget.prototype = widgetProto = {
             throw new Error('Widget does not have a "renderer" property');
         }
 
-        var elToReplace = document.getElementById(self.id);
+        var elToReplace = this.document.getElementById(self.id);
 
         var renderer = self.renderer || self;
         self.__lifecycleState = 'rerender';
@@ -539,7 +539,7 @@ Widget.prototype = widgetProto = {
             var renderResult = raptorRenderer
                 .render(renderer, templateData);
 
-            var newNode = renderResult.getNode();
+            var newNode = renderResult.getNode(self.document);
 
             var out = renderResult.out;
             var widgetsContext = out.global.widgets;
@@ -601,7 +601,7 @@ Widget.prototype = widgetProto = {
             });
 
             // Trigger any 'onUpdate' events for all of the rendered widgets
-            renderResult.afterInsert();
+            renderResult.afterInsert(self.document);
 
             self.__lifecycleState = null;
 

--- a/lib/Widget.js
+++ b/lib/Widget.js
@@ -213,7 +213,7 @@ var widgetProto;
  *
  * NOTE: Any methods that are prefixed with an underscore should be considered private!
  */
-function Widget(id) {
+function Widget(id, document) {
     EventEmitter.call(this);
     this.id = id;
     this.el = null;
@@ -229,6 +229,7 @@ function Widget(id) {
     this.__stateChanges = null;
     this.__updateQueued = false;
     this.__dirtyState = null;
+    this.__document = document;
 }
 
 Widget.prototype = widgetProto = {
@@ -283,9 +284,9 @@ Widget.prototype = widgetProto = {
     },
     getEl: function (widgetElId, index) {
         if (widgetElId != null) {
-            return this.document.getElementById(this.getElId(widgetElId, index));
+            return this.__document.getElementById(this.getElId(widgetElId, index));
         } else {
-            return this.el || this.document.getElementById(this.getElId());
+            return this.el || this.__document.getElementById(this.getElId());
         }
     },
     getEls: function(id) {
@@ -303,7 +304,7 @@ Widget.prototype = widgetProto = {
     },
     getWidget: function(id, index) {
         var targetWidgetId = this.getElId(id, index);
-        return markoWidgets.getWidgetForEl(targetWidgetId, this.document);
+        return markoWidgets.getWidgetForEl(targetWidgetId, this.__document);
     },
     getWidgets: function(id) {
         var widgets = [];
@@ -518,7 +519,7 @@ Widget.prototype = widgetProto = {
             throw new Error('Widget does not have a "renderer" property');
         }
 
-        var elToReplace = this.document.getElementById(self.id);
+        var elToReplace = this.__document.getElementById(self.id);
 
         var renderer = self.renderer || self;
         self.__lifecycleState = 'rerender';
@@ -539,7 +540,7 @@ Widget.prototype = widgetProto = {
             var renderResult = raptorRenderer
                 .render(renderer, templateData);
 
-            var newNode = renderResult.getNode(self.document);
+            var newNode = renderResult.getNode(self.__document);
 
             var out = renderResult.out;
             var widgetsContext = out.global.widgets;
@@ -601,7 +602,7 @@ Widget.prototype = widgetProto = {
             });
 
             // Trigger any 'onUpdate' events for all of the rendered widgets
-            renderResult.afterInsert(self.document);
+            renderResult.afterInsert(self.__document);
 
             self.__lifecycleState = null;
 

--- a/lib/WidgetsContext.js
+++ b/lib/WidgetsContext.js
@@ -92,9 +92,9 @@ WidgetsContext.prototype = {
     _nextWidgetId: function () {
         return uniqueId(this.out);
     },
-    initWidgets: function () {
+    initWidgets: function (document) {
         var widgetDefs = this.widgets;
-        initWidgets.initClientRendered(widgetDefs);
+        initWidgets.initClientRendered(widgetDefs, document);
         this.clearWidgets();
     },
     onBeginWidget: function(listener) {

--- a/lib/defineWidget.js
+++ b/lib/defineWidget.js
@@ -54,8 +54,8 @@ module.exports = function defineWidget(def, renderer) {
     // Instead, we store their constructor in the "initWidget"
     // property and that method gets called later inside
     // init-widgets-browser.js
-    function Widget(id) {
-        BaseWidget.call(this, id);
+    function Widget(id, document) {
+        BaseWidget.call(this, id, document);
     }
 
     if (!proto._isWidget) {

--- a/lib/init-widgets-browser.js
+++ b/lib/init-widgets-browser.js
@@ -42,7 +42,7 @@ function parseJSON(config) {
     return eval('(' + config + ')');
 }
 
-function getNestedEl(widget, nestedId) {
+function getNestedEl(widget, nestedId, document) {
     if (nestedId == null) {
         return null;
 
@@ -69,7 +69,8 @@ function initWidget(
     extendList,
     bodyElId,
     existingWidget,
-    el) {
+    el,
+    document) {
 
     var i;
     var len;
@@ -95,6 +96,7 @@ function initWidget(
         widget = existingWidget;
     } else {
         widget = registry.createWidget(type, id);
+        widget.document = document;
     }
 
     if (state) {
@@ -123,7 +125,7 @@ function initWidget(
 
     if (widget._isWidget) {
         widget.el = el;
-        widget.bodyEl = getNestedEl(widget, bodyElId);
+        widget.bodyEl = getNestedEl(widget, bodyElId, document);
 
         if (domEvents) {
             var eventListenerHandles = [];
@@ -132,7 +134,7 @@ function initWidget(
                 eventType = domEvents[i];
                 targetMethodName = domEvents[i+1];
                 var eventElId = domEvents[i+2];
-                var eventEl = getNestedEl(widget, eventElId);
+                var eventEl = getNestedEl(widget, eventElId, document);
 
                 // The event mapping is for a DOM event (not a custom event)
                 var eventListenerHandle = addDOMEventListener(widget, eventEl, eventType, targetMethodName);
@@ -208,6 +210,7 @@ function initWidgetFromEl(el) {
         return;
     }
 
+    var document = el.ownerDocument;
     var scope;
     var id = el.id;
     var type = el.getAttribute('data-widget');
@@ -264,17 +267,19 @@ function initWidgetFromEl(el) {
         extendList,
         bodyElId,
         null,
-        el);
+        el,
+        document);
 }
 
 
 // Create a helper function handle recursion
-function initClientRendered(widgetDefs) {
+function initClientRendered(widgetDefs, document) {
+    document = document || window.document;
     for (var i=0,len=widgetDefs.length; i<len; i++) {
         var widgetDef = widgetDefs[i];
 
         if (widgetDef.children.length) {
-            initClientRendered(widgetDef.children);
+            initClientRendered(widgetDef.children, document);
         }
 
         var widget = initWidget(
@@ -287,7 +292,9 @@ function initClientRendered(widgetDefs) {
             widgetDef.customEvents,
             widgetDef.extend,
             widgetDef.bodyElId,
-            widgetDef.existingWidget);
+            widgetDef.existingWidget,
+            null,
+            document);
 
         widgetDef.widget = widget;
     }

--- a/lib/init-widgets-browser.js
+++ b/lib/init-widgets-browser.js
@@ -95,8 +95,7 @@ function initWidget(
         existingWidget._reset();
         widget = existingWidget;
     } else {
-        widget = registry.createWidget(type, id);
-        widget.document = document;
+        widget = registry.createWidget(type, id, document);
     }
 
     if (state) {

--- a/lib/marko-widgets-browser.js
+++ b/lib/marko-widgets-browser.js
@@ -38,12 +38,12 @@ exports.writeDomEventsEl = function() {
     /* Intentionally empty in the browser */
 };
 
-function getWidgetForEl(id) {
+function getWidgetForEl(id, document) {
     if (!id) {
         return undefined;
     }
 
-    var node = typeof id === 'string' ? document.getElementById(id) : id;
+    var node = typeof id === 'string' ? (document || window.document).getElementById(id) : id;
     return (node && node.__widget) || undefined;
 }
 
@@ -69,7 +69,7 @@ raptorPubsub
         var out = eventArgs.out || eventArgs.context;
         var widgetsContext = out.global.widgets;
         if (widgetsContext) {
-            widgetsContext.initWidgets();
+            widgetsContext.initWidgets(eventArgs.document);
         }
     });
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -72,14 +72,15 @@ function getWidgetClass(path) {
 
 exports.load = load;
 
-exports.createWidget = function(path, id) {
+exports.createWidget = function(path, id, document) {
     var WidgetClass = getWidgetClass(path);
     var widget;
     if (typeof WidgetClass === 'function') {
         // The widget is a constructor function that we can invoke to create a new instance of the widget
-        widget = new WidgetClass(id);
+        widget = new WidgetClass(id, document);
     } else if (WidgetClass.initWidget) {
         widget = WidgetClass;
+        widget.__document = document;
     }
     return widget;
 };

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-    "name": "marko-widgets",
-    "description": "Module to support binding of behavior to rendered UI components rendered on the server or client",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/marko-js/marko-widgets.git"
-    },
-    "scripts": {
-        "init-tests": "./test/init-tests.sh",
-        "test": "npm run init-tests && npm run test-server -s && npm run test-client -s && npm run jshint --silent",
-        "test-server": "npm run init-tests && node_modules/.bin/mocha --ui bdd --reporter spec ./test/server",
-        "test-client": "npm run init-tests && node test/mocha-phantomjs/run.js",
-        "mocha-phantomjs": "npm run init-tests && node test/mocha-phantomjs/run.js",
-        "mocha-phantomjs-run": "mocha-phantomjs ./test/mocha-phantomjs/generated/test-page.html",
-        "jshint": "jshint lib/ taglib/ *.js"
-    },
-    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "dependencies": {
-        "events": "^1.0.2",
-        "listener-tracker": "^1.0.2",
-        "morphdom": "^1.0.1",
-        "raptor-async": "^1.1.2",
-        "raptor-dom": "^1.1.0",
-        "raptor-json": "^1.0.1",
-        "raptor-logging": "^1.0.1",
-        "raptor-modules": "^1.0.22",
-        "raptor-polyfill": "^1.0.0",
-        "raptor-pubsub": "^1.0.2",
-        "raptor-renderer": "^1.4.1",
-        "raptor-util": "^1.0.0",
-        "resolve-from": "^1.0.1",
-        "try-require": "^1.2.1"
-    },
-    "devDependencies": {
-        "app-module-path": "^1.0.1",
-        "async": "^0.9.0",
-        "chai": "~1.8.1",
-        "ignoring-watcher": "^1.0.2",
-        "jquery": "^2.1.3",
-        "jshint": "^2.5.0",
-        "lasso": "^1.10.0",
-        "lasso-marko": "^2.0.4",
-        "marko": "^2.7.6",
-        "mkdirp": "^0.5.0",
-        "mocha": "~1.15.1",
-        "mocha-phantomjs": "^3.5.3",
-        "phantomjs": "1.9.7-15",
-        "raptor-args": "^1.0.2",
-        "raptor-strings": "^1.0.0"
-    },
-    "license": "Apache License v2.0",
-    "bin": {},
-    "main": "lib/marko-widgets.js",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/"
-    },
-    "version": "5.0.9"
+  "name": "marko-widgets",
+  "description": "Module to support binding of behavior to rendered UI components rendered on the server or client",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marko-js/marko-widgets.git"
+  },
+  "scripts": {
+    "init-tests": "./test/init-tests.sh",
+    "test": "npm run init-tests && npm run test-server -s && npm run test-client -s && npm run jshint --silent",
+    "test-server": "npm run init-tests && node_modules/.bin/mocha --ui bdd --reporter spec ./test/server",
+    "test-client": "npm run init-tests && node test/mocha-phantomjs/run.js",
+    "mocha-phantomjs": "npm run init-tests && node test/mocha-phantomjs/run.js",
+    "mocha-phantomjs-run": "mocha-phantomjs ./test/mocha-phantomjs/generated/test-page.html",
+    "jshint": "jshint lib/ taglib/ *.js"
+  },
+  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "dependencies": {
+    "events": "^1.0.2",
+    "listener-tracker": "^1.0.2",
+    "morphdom": "^1.0.1",
+    "raptor-async": "^1.1.2",
+    "raptor-dom": "^1.1.0",
+    "raptor-json": "^1.0.1",
+    "raptor-logging": "^1.0.1",
+    "raptor-modules": "^1.0.22",
+    "raptor-polyfill": "^1.0.0",
+    "raptor-pubsub": "^1.0.2",
+    "raptor-renderer": "^1.4.4",
+    "raptor-util": "^1.0.0",
+    "resolve-from": "^1.0.1",
+    "try-require": "^1.2.1"
+  },
+  "devDependencies": {
+    "app-module-path": "^1.0.1",
+    "async": "^0.9.0",
+    "chai": "~1.8.1",
+    "ignoring-watcher": "^1.0.2",
+    "jquery": "^2.1.3",
+    "jshint": "^2.5.0",
+    "lasso": "^1.10.0",
+    "lasso-marko": "^2.0.4",
+    "marko": "^2.7.6",
+    "mkdirp": "^0.5.0",
+    "mocha": "~1.15.1",
+    "mocha-phantomjs": "^3.5.3",
+    "phantomjs": "1.9.7-15",
+    "raptor-args": "^1.0.2",
+    "raptor-strings": "^1.0.0"
+  },
+  "license": "Apache License v2.0",
+  "bin": {},
+  "main": "lib/marko-widgets.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "version": "5.0.9"
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -17,8 +17,8 @@
         "unescape"
     ],
 
-    "globals": { 
-        "define": true, 
+    "globals": {
+        "define": true,
         "require": true
     },
 
@@ -48,7 +48,6 @@
     "eqeqeq": false,
     "latedef": true,
     "unused": "vars",
-    
-    /* Relaxing options: */
-    "eqnull": true
+    "eqnull": true,
+    "expr": true
 }

--- a/test/client/spec-widget.js
+++ b/test/client/spec-widget.js
@@ -683,4 +683,20 @@ describe('widget' , function() {
         expect(widget.el.innerHTML).to.contain('Frank');
         expect(widget.el.innerHTML).to.contain('30');
     });
+
+    it('should allow widgets to be rendered to different frame or window', function() {
+        var widget = require('../fixtures/components/app-iframe')
+            .render({})
+            .appendTo(document.getElementById('target'))
+            .getWidget();
+
+        expect(widget.__document).to.exist;
+        expect(widget.__document).to.equal(document);
+
+        var contentWidget = widget.renderIntoIframe();
+        expect(contentWidget.__document).to.equal(widget.getFrameEl().contentWindow.document);
+        expect(contentWidget.getEl('input').value).to.equal('test');
+
+        expect(contentWidget.getWidget('more').getValue()).to.equal('hello');
+    });
 });

--- a/test/fixtures/components/app-iframe-content/index.js
+++ b/test/fixtures/components/app-iframe-content/index.js
@@ -1,0 +1,3 @@
+module.exports = require('marko-widgets').defineComponent({
+	template: require.resolve('./template.marko')
+});

--- a/test/fixtures/components/app-iframe-content/template.marko
+++ b/test/fixtures/components/app-iframe-content/template.marko
@@ -1,0 +1,5 @@
+<div w-bind>
+    <input w-id="input" type="text" value="test" />
+    <button w-id="button" />
+    <app-iframe-more-content w-id="more" />
+</div>

--- a/test/fixtures/components/app-iframe-more-content/index.js
+++ b/test/fixtures/components/app-iframe-more-content/index.js
@@ -1,0 +1,7 @@
+module.exports = require('marko-widgets').defineComponent({
+	template: require.resolve('./template.marko'),
+
+	getValue: function() {
+		return this.getEl('input').value;
+	}
+});

--- a/test/fixtures/components/app-iframe-more-content/template.marko
+++ b/test/fixtures/components/app-iframe-more-content/template.marko
@@ -1,0 +1,3 @@
+<div w-bind>
+    <input w-id="input" type="text" value="hello" />
+</div>

--- a/test/fixtures/components/app-iframe/index.js
+++ b/test/fixtures/components/app-iframe/index.js
@@ -1,0 +1,15 @@
+var IframeContentComponent = require('../app-iframe-content');
+
+module.exports = require('marko-widgets').defineComponent({
+	template: require.resolve('./template.marko'),
+
+	renderIntoIframe: function() {
+		var frameEl = this.getFrameEl();
+		return IframeContentComponent.render({}).appendTo(
+			frameEl.contentWindow.document.body).getWidget();
+	},
+
+	getFrameEl: function() {
+		return this.getEl('frame');
+	}
+});

--- a/test/fixtures/components/app-iframe/template.marko
+++ b/test/fixtures/components/app-iframe/template.marko
@@ -1,0 +1,3 @@
+<div class="foo" w-bind>
+    <iframe w-id="frame"></iframe>
+</div>


### PR DESCRIPTION
If a widget is rendered to a different frame then the `document` that is used to find nested widgets and elements should be the `document` that the widget was rendered to.

This change explicitly provides a `document` property to a `Widget` which is used during the initialization process and subsequent nested widget and element lookups.