### PR TITLE
Replacing falsey check from this.shouldUpdate

### DIFF
--- a/lib/Widget.js
+++ b/lib/Widget.js
@@ -392,7 +392,7 @@ Widget.prototype = widgetProto = {
     update: function() {
         var newProps = this.__newProps;
 
-        if (!this.shouldUpdate(newProps, this.state)) {
+        if (this.shouldUpdate(newProps, this.state) === false) {
             resetWidget(this);
             return;
         }


### PR DESCRIPTION
The [documentation](http://markojs.com/docs/marko-widgets/get-started/#shouldupdatenewprops-newstate) states that returning `false` from this.shouldUpdate will prevent the view from being updated.

However, this check is falsey, and will not update for falsey values as well. PR for consistency.