### PR TITLE
update docs for rerender in javascript api

### DIFF
--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -216,7 +216,9 @@ Replaces the state with an entirely new state. If any of the state properties ch
 Important to know:
 While `setState()` is additive and will not remove properties that are in the old state but not in the new state, `replaceState()` will add the new state and remove the old state properties that are not found in the new state. State or template data values that are derived from state properties that are not part of the new state, are `undefined`. Thus, if `replaceState()` is used, one must consider possible side effects if the new state contains less or other properties than the replaced state.
 
-### rerender(data, callback)
+### rerender(data)
+
+Rerenders the widget using its `renderer` and either supplied `data` or internal `state`.
 
 ### setState(name, value)
 


### PR DESCRIPTION
Noticed that the API method signature has `callback`, although it doesn't exist (https://github.com/marko-js/marko-widgets/blob/master/lib/Widget.js#L515). Not sure if you intended to introduce a callback parameter there at some point.