### PR TITLE
add cspNonce support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,8 +166,8 @@ exports.writeInitWidgetsCode = function(widgetsContext, out, options) {
                     ';\n';
         }
 
-        var cspNonce = JSON.stringify(out.global.cspNonce);
-        var nonceAttr = cspNonce ? ' nonce='+cspNonce : '';
+        var cspNonce = out.global.cspNonce;
+        var nonceAttr = cspNonce ? ' nonce='+JSON.stringify(cspNonce) : '';
 
         if (immediate) {
             out.write('<script' + nonceAttr + '>' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,13 +166,16 @@ exports.writeInitWidgetsCode = function(widgetsContext, out, options) {
                     ';\n';
         }
 
+        var cspNonce = JSON.stringify(out.global.cspNonce);
+        var nonceAttr = cspNonce ? ' nonce='+cspNonce : '';
+
         if (immediate) {
-            out.write('<script>' +
+            out.write('<script' + nonceAttr + '>' +
                 widgetStateDeserializationCode +
                 widgetConfigDeserializationCode +
                 '$markoWidgets("' + ids + '")</script>');
         } else {
-            out.write('<script>' +
+            out.write('<script' + nonceAttr + '>' +
                 widgetStateDeserializationCode +
                 widgetConfigDeserializationCode +
                 '</script>');

--- a/test/autotests-server/cspNonce/components/app-simple/index.js
+++ b/test/autotests-server/cspNonce/components/app-simple/index.js
@@ -1,0 +1,26 @@
+module.exports = require('marko-widgets').defineComponent({
+	template: require.resolve('./template.marko'),
+
+	getWidgetConfig: function() {
+		return {
+			type: 'widget config'
+		};
+	},
+
+	getInitialState: function() {
+		return {
+			type: 'widget state'
+		};
+	},
+
+	getTemplateData: function(state, input) {
+		return {
+			name: input.name,
+            messageCount: input.messageCount
+		};
+	},
+
+	init: function(widgetConfig) {
+		this.widgetConfig = widgetConfig;
+	}
+});

--- a/test/autotests-server/cspNonce/components/app-simple/template.marko
+++ b/test/autotests-server/cspNonce/components/app-simple/template.marko
@@ -1,0 +1,4 @@
+<div w-bind>
+	Hello ${data.name}! You have ${data.messageCount} new messages.
+	<div w-id="foo">foo</div>
+</div>

--- a/test/autotests-server/cspNonce/marko.json
+++ b/test/autotests-server/cspNonce/marko.json
@@ -1,0 +1,3 @@
+{
+    "tags-dir": "./components"
+}

--- a/test/autotests-server/cspNonce/template.marko
+++ b/test/autotests-server/cspNonce/template.marko
@@ -1,0 +1,6 @@
+<div>
+	<app-simple name="Frank" count=20/>
+	<app-simple name="John" count=30/>
+</div>
+
+<init-widgets immediate=true/>

--- a/test/autotests-server/cspNonce/test.js
+++ b/test/autotests-server/cspNonce/test.js
@@ -1,0 +1,13 @@
+var expect = require('chai').expect;
+var markoWidgets = require('marko-widgets');
+
+module.exports = function(helpers, done) {
+    var template = require('./template.marko');
+
+    template.render({ $global:{ cspNonce:'abc123' }}, function(err, html, out) {
+        if(!/<script.*nonce="abc123".*>/.test(html)) {
+            throw new Error('script tag does not contain a nonce');
+        }
+        done();
+	});
+};


### PR DESCRIPTION
Allows passing `out.global.cspNonce` which will add a nonce attribute to the script tag generated by Marko Widgets.

@patrick-steele-idem Is this the only script tag that is generated?