### PR TITLE
Fixes #165 event-delegation.js:44 Uncaught TypeError: Cannot read property '__widget' of null

### DIFF
--- a/lib/event-delegation.js
+++ b/lib/event-delegation.js
@@ -41,7 +41,16 @@ var attachBubbleEventListeners = function() {
                     if ((targetMethod = curNode.getAttribute(attrName))) {
                         var separator = targetMethod.lastIndexOf('|');
                         var targetWidgetId = targetMethod.substring(separator+1);
-                        targetWidget = document.getElementById(targetWidgetId).__widget;
+                        var targetWidgetEl = document.getElementById(targetWidgetId);
+                        if (!targetWidgetEl) {
+                            // The target widget is not in the DOM anymore
+                            // which can happen when the widget and its
+                            // children are removed from the DOM while
+                            // processing the event.
+                            continue;
+                        }
+
+                        targetWidget = targetWidgetEl.__widget;
 
                         if (!targetWidget) {
                             throw new Error('Widget not found: ' + targetWidgetId);


### PR DESCRIPTION
@patrick-steele-idem @mlrawlings this change fixes an issue that we see in our code when destroying a widget while handling an event. Please review, merge, and publish if you like the fix.