### PR TITLE
deprecate calling render synchronously.  use renderSync instead.

### DIFF
--- a/lib/defineRenderer.js
+++ b/lib/defineRenderer.js
@@ -158,7 +158,21 @@ module.exports = function defineRenderer(def) {
         };
     }
 
-    renderer.render = raptorRenderer.createRenderFunc(renderer);
+    renderer.render = function(data, callback) {
+        if(!callback) {
+            require('./deprecate').warn(
+                'Calling `render` synchronously is deprecated. '+
+                'Use `renderSync` instead.'
+            );
+            return raptorRenderer.render(renderer, data);
+        }
+
+        raptorRenderer.render(renderer, data, callback);
+    };
+
+    renderer.renderSync = function(data) {
+        return raptorRenderer.render(renderer, data);
+    };
 
     return renderer;
 };

--- a/lib/defineWidget-browser.js
+++ b/lib/defineWidget-browser.js
@@ -26,6 +26,7 @@ module.exports = function defineWidget(def, renderer) {
         return {
             renderer: renderer,
             render: renderer.render,
+            renderSync: renderer.renderSync,
             extendWidget: function(widget) {
                 extendWidget(widget);
                 widget.renderer = renderer;
@@ -82,6 +83,7 @@ module.exports = function defineWidget(def, renderer) {
         // new widget constructor function
         Widget.renderer = proto.renderer = renderer;
         Widget.render = renderer.render;
+        Widget.renderSync = renderer.renderSync;
     }
 
     return Widget;

--- a/lib/defineWidget.js
+++ b/lib/defineWidget.js
@@ -23,7 +23,8 @@ module.exports = function defineWidget(def, renderer) {
         return {
             _isWidget: true,
             renderer: renderer,
-            render: renderer.render
+            render: renderer.render,
+            renderSync: renderer.renderSync
         };
     } else {
         return {_isWidget: true};

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -1,0 +1,78 @@
+var logger = typeof console !== 'undefined' && console.warn && console;
+var messageCounts = {};
+
+module.exports = function(o, methodName, message) {
+    if (!logger) return;
+
+    var originalMethod = o[methodName];
+
+    o[methodName] = function() {
+        var remainingWarns = warn(message);
+
+        if (!remainingWarns) {
+            o[methodName] = originalMethod;
+        }
+
+        return originalMethod.apply(this, arguments);
+    };
+};
+
+module.exports.warn = warn;
+
+function warn(message) {
+    if (!logger) return 0;
+
+    var maxWarn = 20;
+    var stack;
+    messageCounts[message] = messageCounts[message] || 0;
+
+    if (messageCounts[message] < maxWarn) {
+        messageCounts[message]++;
+        try {
+            stack = (new Error()).stack.split('\n').slice(4).join('\n');
+        } catch(e) {}
+        logger.warn(red('WARNING!!') + '\n' + message + '\n' + grey(stack || ''));
+    }
+
+    return maxWarn - messageCounts[message];
+}
+
+var canFormat = (function () {
+    try {
+        if (process.stdout && !process.stdout.isTTY) {
+            return false;
+        }
+
+        if (process.platform === 'win32') {
+            return true;
+        }
+
+        if ('COLORTERM' in process.env) {
+            return true;
+        }
+
+        if (process.env.TERM === 'dumb') {
+            return false;
+        }
+
+        if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+            return true;
+        }
+    } catch(e){}
+
+    return false;
+})();
+
+function format(str, begin, end) {
+    begin = canFormat ? '\u001b['+begin+'m' : '';
+    end = canFormat ? '\u001b['+end+'m' : '';
+    return begin + str + end;
+}
+
+function red(str) {
+    return format(str, 31, 39);
+}
+
+function grey(str) {
+    return format(str, 90, 39);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,23 @@ exports.getRenderedWidgets = exports.getRenderedWidgetIds /* deprecated */ = fun
     return result;
 };
 
-exports.makeRenderable = exports.renderable = raptorRenderer.renderable;
+exports.makeRenderable = exports.renderable = function(target, renderer) {
+    target.renderer = renderer;
+    target.render = function(data, callback) {
+        if(!callback) {
+            require('./deprecate').warn(
+                'Calling `render` synchronously is deprecated. '+
+                'Use `renderSync` instead.'
+            );
+            return raptorRenderer.render(renderer, data);
+        }
+
+        raptorRenderer.render(renderer, data, callback);
+    };
+    target.renderSync = function(data) {
+        return raptorRenderer.render(renderer, data);
+    };
+};
 exports.render = raptorRenderer.render;
 
 exports.defineComponent = require('./defineComponent');


### PR DESCRIPTION
**Old:**
```js
widget.render({}).appendTo();
```

**New:**
```js
widget.renderSync({}).appendTo();
```